### PR TITLE
remove :page-aliases: attribute

### DIFF
--- a/modules/userprofile/pages/android/userprofile_query.adoc
+++ b/modules/userprofile/pages/android/userprofile_query.adoc
@@ -3,7 +3,6 @@
 :idseparator: -
 :icons: font
 :quick-uri: https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/
-:page-aliases: tutorials:userprofile-couchbase-mobile:query/userprofile/userprofile_query
 ifndef::env-site,env-github[]
 :toc: left
 :toclevels: 3


### PR DESCRIPTION
The :page-aliases: attribute is used to add redirect URLs.

For example, https://docs.couchbase.com/tutorials/userprofile-couchbase-mobile/query/userprofile/userprofile_query.html redirects to https://docs.couchbase.com/userprofile-couchbase-mobile/query/userprofile/userprofile_query.html

This redirect is needed because content from the https://github.com/couchbaselabs/userprofile-couchbase-mobile was previously hosted at another location.

Content from the -android and -xamarin repos were first published at the new location therefore we don't need the :page-aliases: attribute