### PR TITLE
Updated the Installing Sync Gateway using Docker link

### DIFF
--- a/modules/userprofile/pages/android/userprofile_sync.adoc
+++ b/modules/userprofile/pages/android/userprofile_sync.adoc
@@ -587,6 +587,6 @@ Check out the following links for further details
 
 * link:https://blog.couchbase.com/data-replication-couchbase-mobile/[Overview of Replication Protocol 2.0]
 
-* link:https://blog.couchbase.com/couchbase-mobile-docker/[Installing Sync Gateway using Docker]
+* link:https://blog.couchbase.com/using-docker-with-couchbase-mobile/[Installing Sync Gateway using Docker]
 
 


### PR DESCRIPTION
Updated the Installing Sync Gateway using the Docker link as the current URL "https://blog.couchbase.com/couchbase-mobile-docker/" is leading to Page not found error.
Updated URL: https://blog.couchbase.com/using-docker-with-couchbase-mobile/