### PR TITLE
Need to update the blog link for "Installing Sync Gateway using Docker"

### DIFF
--- a/modules/userprofile/pages/android/userprofile_sync.adoc
+++ b/modules/userprofile/pages/android/userprofile_sync.adoc
@@ -587,6 +587,6 @@ Check out the following links for further details
 
 * link:https://blog.couchbase.com/data-replication-couchbase-mobile/[Overview of Replication Protocol 2.0]
 
-* link:https://blog.couchbase.com/couchbase-mobile-docker/[Installing Sync Gateway using Docker]
+* link:https://blog.couchbase.com/using-docker-with-couchbase-mobile/[Installing Sync Gateway using Docker]
 
 


### PR DESCRIPTION
Can we please update the blog link from "https://blog.couchbase.com/couchbase-mobile-docker/" to "https://blog.couchbase.com/using-docker-with-couchbase-mobile/" ?
The current blog link leads to the "page not found" error.
Thank you